### PR TITLE
Added option to state that one wants to explicitly close connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Uses [phpnats](https://github.com/repejota/phpnats) under the hood and closesly 
 ## Requirements
 
 * php 5.6+
-* [stan](https://github.com/nats-io/nats-streaming-server)
 
 
 ## Installation
@@ -37,7 +36,7 @@ Get [composer](https://getcomposer.org/):
 curl -O http://getcomposer.org/composer.phar && chmod +x composer.phar
 ```
 
-Add the ON2IT forks to your `composer.json` repositories:
+Add the ON2IT forks to the `repositories` array in your `composer.json`:
 ```json
     "repositories": [
         {
@@ -76,9 +75,6 @@ $gotAck = $r->wait();
 if (!$gotAck) {
     ...
 }
-
-$c->close();
-
 ```
 
 #### Note
@@ -126,9 +122,6 @@ $sub->wait(1);
 
 // not explicitly needed
 $sub->unsubscribe(); // or $sub->close();
-
-$c->close();
-
 ```
 
 If you want to subscribe to multiple channels you can use `$c->wait()`:
@@ -167,9 +160,6 @@ $sub->wait(1);
 
 // not explicitly needed
 $sub->close(); // or $sub->unsubscribe();
-
-$c->close();
-
 ```
 
 ### Manual Ack
@@ -188,9 +178,22 @@ $sub = $c->subscribe('special.subject', function ($message) {
 }, $subOptions);
 
 $sub->wait(1);
+```
 
+### Explicit Close
+
+This library automatically closes the NATS Streaming connection during deconstruction of the `Connection` object. This is probably unwanted behavior in long-running processes, therefore, it is possible to configure you are explicitly closing the connection by yourself.
+
+```php
+$options = new \NatsStreaming\ConnectionOptions([
+    'explicitClose' => true,
+]);
+$c = new \NatsStreaming\Connection($options);
+
+$c->connect();
+
+// Do stuff with $c, but be sure to explicitly close the conncetion manually
 $c->close();
-
 ```
 
 ## License

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "protobuf-php/protobuf-plugin": "^0.1.2",
     "symfony/console": "^2.8@dev",
     "phpunit/phpunit": "5.3.*",
-    "satooshi/php-coveralls": "dev-master",
+    "satooshi/php-coveralls": "^1.0",
     "squizlabs/php_codesniffer": "~2.0",
     "github.com/gogo/protobuf": "dev-master"
   },

--- a/src/NatsStreaming/Connection.php
+++ b/src/NatsStreaming/Connection.php
@@ -447,11 +447,15 @@ class Connection
     }
 
     /**
-     *
      * Disconnect if we haven't
      */
     public function __destruct()
     {
+        // When explicit close is configured, do not close anything implicitly here in the destructor
+        if ($this->options->getExplicitClose()) {
+            return;
+        }
+
         if ($this->isConnected()) {
             $this->close();
         }

--- a/src/NatsStreaming/ConnectionOptions.php
+++ b/src/NatsStreaming/ConnectionOptions.php
@@ -34,6 +34,11 @@ class ConnectionOptions
     private $clientID = '';
 
     /**
+     * @var boolean
+     */
+    private $explicitClose = false;
+
+    /**
      * Allows to define parameters which can be set by passing them to the class constructor.
      *
      * @var array
@@ -45,6 +50,7 @@ class ConnectionOptions
         'natsOptions',
         'clientID',
         'clusterID',
+        'explicitClose',
     ];
 
 
@@ -138,5 +144,23 @@ class ConnectionOptions
     public function getClientID()
     {
         return $this->clientID;
+    }
+
+    /**
+     * @param bool $explicitClose
+     * @return ConnectionOptions
+     */
+    public function setExplicitClose($explicitClose)
+    {
+        $this->explicitClose = $explicitClose;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getExplicitClose()
+    {
+        return $this->explicitClose;
     }
 }

--- a/tests/Unit/ConnectionOptionsTest.php
+++ b/tests/Unit/ConnectionOptionsTest.php
@@ -3,20 +3,33 @@
 class ConnectionOptionsTest extends \PHPUnit_Framework_TestCase
 {
 
+    public function testConstructorDefaults()
+    {
+        $opts = new \NatsStreaming\ConnectionOptions();
+
+        $this->assertEquals('', $opts->getDiscoverPrefix());
+        $this->assertEquals('', $opts->getClientID());
+        $this->assertEquals('test-cluster', $opts->getClusterID());
+        $this->assertFalse($opts->getExplicitClose());
+
+        $this->assertNull($opts->getNatsOptions());
+    }
+
     public function testConstructor()
     {
-
         $opts = new \NatsStreaming\ConnectionOptions([
             'discoverPrefix' => 'foo',
             'clientID' => 'bar',
             'clusterID' =>'baz',
+            'explicitClose' => true,
             'foobar' => 'baz',
-            'natsOptions' => new \Nats\ConnectionOptions(['host' => 'hosty'])
+            'natsOptions' => new \Nats\ConnectionOptions(['host' => 'hosty']),
         ]);
 
         $this->assertEquals('foo', $opts->getDiscoverPrefix());
         $this->assertEquals('bar', $opts->getClientID());
         $this->assertEquals('baz', $opts->getClusterID());
+        $this->assertTrue($opts->getExplicitClose());
 
         $this->assertEquals('hosty', $opts->getNatsOptions()->getHost());
     }


### PR DESCRIPTION
This library automatically closes the NATS Streaming connection during deconstruction of the Connection object. This is probably unwanted behavior in long-running processes, therefore, it is possible to configure you are explicitly closing the connection by yourself.